### PR TITLE
Update accounting documentation for current schema

### DIFF
--- a/docs/accounting-basics.md
+++ b/docs/accounting-basics.md
@@ -205,16 +205,30 @@ $product = Product::create([
 ```php
 class Document extends Model {
     protected $fillable = [
-        'number',       // شماره سند (یکتا در سال مالی)
+        'number',       // شماره سند (عددی که در سال مالی یکتا می‌شود)
         'date',         // تاریخ سند
         'title',        // شرح کلی سند
-        'permanent',    // آیا سند دائمی است یا موقت
+        'approved_at',  // تاریخ تأیید سند
         'creator_id',   // شناسه کاربر ایجادکننده
-        'company_id',   // شناسه شرکت (سال مالی)
+        'approver_id',  // شناسه کاربر تأییدکننده
+        'company_id',   // شناسه شرکت/سال مالی
     ];
-    
+
+    protected $casts = [
+        'date' => 'date',
+        'approved_at' => 'date',
+    ];
+
     public function transactions() {
         return $this->hasMany(Transaction::class);
+    }
+
+    public function creator() {
+        return $this->belongsTo(User::class, 'creator_id');
+    }
+
+    public function approver() {
+        return $this->belongsTo(User::class, 'approver_id');
     }
 }
 
@@ -235,33 +249,6 @@ class Transaction extends Model {
     public function getCreditAttribute() {
         return $this->value < 0 ? formatNumber(-1 * $this->value) : '';
     }
-}
-```
-
-### اسناد خودکار و رابطه Morph
-
-اسناد خودکار (فاکتور، چک، ...) از طریق رابطه Polymorphic به سند متصل هستند:
-
-```php
-class Invoice extends Model {
-    public function document() {
-        return $this->morphOne(Document::class, 'documentable');
-    }
-}
-
-// چک
-class Cheque extends Model {
-    public function document() {
-        return $this->morphOne(Document::class, 'documentable');
-    }
-}
-```
-
-**نکته بسیار مهم**: اگر سندی رابطه morph داشته باشد، نباید اجازه ویرایش دستی داشته باشد چون از سینک بودن خارج می‌شود:
-
-```php
-if ($document->documentable_type && $document->documentable_id) {
-    throw new \Exception('اسناد خودکار قابل ویرایش دستی نیستند');
 }
 ```
 
@@ -325,13 +312,18 @@ DocumentService::deleteDocument($documentId);
 برای ایجاد سرفصل‌ها (برای تولید خودکار کد حسابداری حتما از این سرویس استفاده کنید):
 
 ```php
+use App\Models\Subject;
 use App\Services\SubjectCreatorService;
 
 $subjectService = new SubjectCreatorService();
+
+// ابتدا سرفصل والد را پیدا کنید (مثلاً صندوق اصلی)
+$parentSubject = Subject::where('code', '011001')->firstOrFail();
+
 $subject = $subjectService->createSubject([
     'name' => 'صندوق جدید',
-    'parent_code' => '011001',
-    'code' => '005'  // اختیاری
+    'parent_id' => $parentSubject->id,
+    'type' => 'debtor',   // اختیاری؛ مقدار پیش‌فرض 'both' است
 ]);
 ```
 
@@ -359,15 +351,19 @@ $availableSections = FiscalYearService::getAvailableSections();
 ## سال مالی و چندشرکته بودن
 
 ### مفهوم سال مالی در امیر
-سال مالی در امیر به عنوان "شرکت" (Company) شناخته می‌شود. هر شرکت نمایانگر یک سال مالی مستقل است.
+سال مالی در امیر به عنوان "شرکت" (Company) شناخته می‌شود. هر شرکت نمایانگر یک سال مالی مستقل است و مقدار عددی سال (مثلاً 1403) در ستون `fiscal_year` همان رکورد نگهداری می‌شود.
 
 ```php
-class Company extends Model {    // در واقع FiscalYear است
+class Company extends Model {    // هر ردیف نمایانگر یک سال مالی است
     protected $fillable = [
-        'name',          // "سال مالی 1403"
-        'start_date',    // "1403/01/01"
-        'end_date',      // "1403/12/29"
-        'is_closed',     // بسته شده یا خیر
+        'name',            // عنوان سال/شرکت (مانند "سال مالی 1403")
+        'logo',            // مسیر لوگو (اختیاری)
+        'address',         // آدرس شرکت
+        'economical_code', // کد اقتصادی
+        'national_code',   // شناسه ملی
+        'postal_code',     // کد پستی
+        'phone_number',    // تلفن تماس
+        'fiscal_year',     // سال مالی به صورت عدد صحیح (مثلاً 1403)
     ];
 }
 ```


### PR DESCRIPTION
## Summary
- align the Document model example with the current columns and remove the unused polymorphic guidance
- show how to call `SubjectCreatorService` with a `parent_id` that matches the subjects schema
- document the real `companies` columns and explain how the `fiscal_year` integer represents the active year

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ce7f8f0384832a8248d4fbf0632e48