### PR TITLE
Update documentation to reflect current project structure

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -91,21 +91,22 @@ Http/
 ```
 
 #### `Models/`
-مدل‌های Eloquent برای پایگاه داده:
+مدل‌های Eloquent موجود در همین پوشه منطق داده را مدیریت می‌کنند. مهم‌ترین فایل‌ها عبارت‌اند از:
 
-**مدل‌های اصلی حسابداری:**
-- `Document.php` - اسناد حسابداری
-- `Transaction.php` - تراکنش‌های مالی
-- `Subject.php` - سرفصل‌های حسابداری
-- `Company.php` - شرکت‌ها
-- `FiscalYear.php` - سال‌های مالی
+- `Document.php` – مدیریت اسناد حسابداری و ارتباط آن‌ها با تراکنش‌ها.
+- `Transaction.php` و `Transaction2.php` – ثبت تراکنش‌های مرتبط با اسناد و سناریوهای فروش.
+- `Subject.php` – ساختار درختی سرفصل‌ها و روابط والد/فرزند آن‌ها.
+- `Company.php` – اطلاعات شرکت و نگه‌داشتن شناسه شرکت فعال.
+- `User.php` – کاربران سیستم و ارتباط آن‌ها با شرکت‌ها.
+- `Customer.php` و `CustomerGroup.php` – مدیریت مشتریان و گروه‌بندی آن‌ها.
+- `Product.php` و `ProductGroup.php` – کالاها و گروه‌های کالایی.
+- `Invoice.php` و `InvoiceItem.php` – فاکتورهای فروش و اقلامشان.
+- `Bank.php`، `BankAccount.php`، `Cheque.php` و `ChequeHistory.php` – مدیریت اطلاعات بانکی و چک‌ها.
+- `Config.php` و `Payment.php` – پیکربندی سیستم و پرداخت‌ها.
 
-**مدل‌های کسب‌وکار:**
-- `Customer.php` - مشتریان
-- `Product.php` - کالاها
-- `Invoice.php` - فاکتورها
-- `Bank.php` - بانک‌ها
-- `BankAccount.php` - حساب‌های بانکی
+زیرپوشه `Scopes/` شامل `FiscalYearScope.php` است که بر روی مدل‌های مرتبط اعمال می‌شود تا داده‌ها به شرکت/سال فعال محدود شوند.
+
+> نکته: مدلی با نام `FiscalYear.php` در پروژه وجود ندارد؛ مدیریت سال/شرکت فعال از طریق مدل `Company` و همین اسکوپ انجام می‌شود.
 
 #### `Services/`
 منطق کسب‌وکار پیچیده:
@@ -153,11 +154,13 @@ class FiscalYearService
 // Example: مایگریشن جدول documents
 Schema::create('documents', function (Blueprint $table) {
     $table->id();
-    $table->string('number')->unique();
-    $table->date('date');
-    $table->text('description')->nullable();
-    $table->foreignId('fiscal_year_id');
-    $table->foreignId('company_id');
+    $table->decimal('number', 16, 2)->nullable();
+    $table->string('title')->nullable();
+    $table->date('date')->nullable();
+    $table->date('approved_at')->nullable();
+    $table->foreignId('creator_id')->nullable()->constrained('users')->nullOnDelete();
+    $table->foreignId('approver_id')->nullable()->constrained('users')->nullOnDelete();
+    $table->foreignId('company_id')->nullable()->constrained()->nullOnDelete();
     $table->timestamps();
 });
 ```
@@ -213,40 +216,24 @@ Route::group(['middleware' => ['auth', 'check-permission']], function () {
 مسیرهای API (در صورت نیاز):
 
 ```php
-Route::middleware('auth:sanctum')->group(function () {
-    Route::apiResource('documents', DocumentApiController::class);
+Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+    return $request->user();
 });
 ```
 
+در حال حاضر فایل تنها شامل نمونه‌ی پیش‌فرض لاراول است و می‌توانید مسیرهای API جدید را در همین گروه اضافه کنید.
+
 ## 🧪 تست‌ها (`tests/`)
 
-### `Feature/`
-تست‌های عملکردی (End-to-End):
+ساختار تست‌ها مطابق استاندارد لاراول است و دو تست نمونه به صورت پیش‌فرض در مخزن حضور دارند:
 
-```php
-// tests/Feature/DocumentTest.php
-class DocumentTest extends TestCase
-{
-    public function test_can_create_balanced_document()
-    {
-        // تست ایجاد سند متوازن
-    }
-}
+```
+tests/
+├── Feature/ExampleTest.php   # بررسی پاسخ موفق صفحه‌ی اصلی
+└── Unit/ExampleTest.php      # تست ساده صحت true
 ```
 
-### `Unit/`
-تست‌های واحد:
-
-```php
-// tests/Unit/DocumentServiceTest.php
-class DocumentServiceTest extends TestCase
-{
-    public function test_validates_document_balance()
-    {
-        // تست اعتبارسنجی موازنه سند
-    }
-}
-```
+برای گسترش پوشش تست‌ها می‌توانید فایل‌های جدید با دستور `php artisan make:test` بسازید یا همین نمونه‌ها را ویرایش کنید. راهنمای تست در `docs/testing-guide.md` توضیحات بیشتری ارائه می‌دهد.
 
 ## 🔧 ابزارهای توسعه
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,854 +1,177 @@
 # راهنمای تست در امیر
 
-این راهنما نحوه نوشتن و اجرای تست‌ها در پروژه امیر را توضیح می‌دهد.
+این راهنما وضعیت فعلی تست‌ها در پروژه را توضیح می‌دهد و نشان می‌دهد چگونه می‌توانید از تست‌های نمونه برای ساخت سناریوهای واقعی‌تر استفاده کنید.
 
-## 🎯 اهمیت تست در سیستم‌های مالی
+## 🎯 چرا تست‌نویسی مهم است؟
 
-در سیستم‌های حسابداری، تست‌نویسی بسیار حیاتی است زیرا:
-- خطاهای محاسباتی می‌توانند باعث عدم تطبیق حساب‌ها شوند
-- منطق حسابداری پیچیده و مستعد خطا است
-- تغییرات کوچک می‌توانند تأثیرات گسترده داشته باشند
-- قوانین مالیاتی و حسابداری باید دقیقاً رعایت شوند
+در سیستم‌های حسابداری و مالی هر تغییر کوچک می‌تواند اثرات بزرگی داشته باشد، بنابراین:
+- مانع ایجاد خطاهای محاسباتی می‌شود.
+- از بازگشت رفتارهای ناخواسته جلوگیری می‌کند.
+- امکان توسعه‌ی مطمئن قابلیت‌های جدید را فراهم می‌کند.
 
-## 🧪 انواع تست در امیر
+## 🧪 وضعیت فعلی پوشه‌ی `tests/`
 
-### 1. Unit Tests
-تست‌های واحد برای تست منطق کلاس‌ها و متدهای مجزا:
+پروژه با تست‌های پیش‌فرض لاراول راه‌اندازی شده است:
 
-```php
-<?php
-namespace Tests\Unit;
-
-use App\Services\DocumentService;
-use App\Exceptions\DocumentServiceException;
-use PHPUnit\Framework\TestCase;
-
-class DocumentServiceTest extends TestCase
-{
-    public function test_calculates_document_balance_correctly()
-    {
-        // Arrange
-        $transactions = [
-            ['debit_amount' => 100000, 'credit_amount' => 0],
-            ['debit_amount' => 0, 'credit_amount' => 100000]
-        ];
-        
-        // Act
-        $isBalanced = DocumentService::isBalanced($transactions);
-        
-        // Assert
-        $this->assertTrue($isBalanced);
-    }
-    
-    public function test_detects_unbalanced_transactions()
-    {
-        // Arrange
-        $transactions = [
-            ['debit_amount' => 100000, 'credit_amount' => 0],
-            ['debit_amount' => 0, 'credit_amount' => 50000]
-        ];
-        
-        // Act
-        $isBalanced = DocumentService::isBalanced($transactions);
-        
-        // Assert
-        $this->assertFalse($isBalanced);
-    }
-    
-    public function test_validates_transaction_amounts()
-    {
-        // Arrange
-        $invalidTransactions = [
-            ['debit_amount' => -100, 'credit_amount' => 0]
-        ];
-        
-        // Act & Assert
-        $this->expectException(DocumentServiceException::class);
-        $this->expectExceptionMessage('مبلغ نمی‌تواند منفی باشد');
-        
-        DocumentService::validateTransactions($invalidTransactions);
-    }
-}
+```
+tests/
+├── Feature/ExampleTest.php   # درخواست GET به صفحه‌ی اصلی و بررسی پاسخ 200
+└── Unit/ExampleTest.php      # تست ساده‌ی true === true
 ```
 
-### 2. Feature Tests
-تست‌های عملکردی برای تست کل workflow:
-
-```php
-<?php
-namespace Tests\Feature;
-
-use App\Models\User;
-use App\Models\Subject;
-use App\Models\Document;
-use App\Models\Company;
-use App\Models\FiscalYear;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class DocumentManagementTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    private User $user;
-    private Company $company;
-    private FiscalYear $fiscalYear;
-    private Subject $cashAccount;
-    private Subject $salesAccount;
-    
-    protected function setUp(): void
-    {
-        parent::setUp();
-        
-        // ایجاد داده‌های مورد نیاز برای تست
-        $this->user = User::factory()->create();
-        $this->company = Company::factory()->create();
-        $this->fiscalYear = FiscalYear::factory()->create([
-            'company_id' => $this->company->id
-        ]);
-        
-        $this->cashAccount = Subject::factory()->create([
-            'type' => 'asset',
-            'code' => '1.1.1.001',
-            'title' => 'صندوق'
-        ]);
-        
-        $this->salesAccount = Subject::factory()->create([
-            'type' => 'income',
-            'code' => '4.1.1.001',
-            'title' => 'فروش'
-        ]);
-        
-        // تنظیم session برای شرکت فعال
-        session(['active-company-id' => $this->company->id]);
-    }
-    
-    public function test_user_can_create_document_via_form()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        
-        // Act
-        $response = $this->post(route('documents.store'), [
-            'date' => '2024-01-15',
-            'description' => 'فروش نقدی کالا',
-            'transactions' => [
-                [
-                    'subject_id' => $this->cashAccount->id,
-                    'debit_amount' => 100000,
-                    'credit_amount' => 0,
-                    'description' => 'دریافت وجه نقد'
-                ],
-                [
-                    'subject_id' => $this->salesAccount->id,
-                    'debit_amount' => 0,
-                    'credit_amount' => 100000,
-                    'description' => 'درآمد فروش'
-                ]
-            ]
-        ]);
-        
-        // Assert
-        $response->assertRedirect();
-        $response->assertSessionHas('success');
-        
-        $this->assertDatabaseHas('documents', [
-            'description' => 'فروش نقدی کالا',
-            'company_id' => $this->company->id
-        ]);
-        
-        $document = Document::where('description', 'فروش نقدی کالا')->first();
-        $this->assertCount(2, $document->transactions);
-        $this->assertEquals(100000, $document->total_debit);
-        $this->assertEquals(100000, $document->total_credit);
-        $this->assertTrue($document->is_balanced);
-    }
-    
-    public function test_cannot_create_unbalanced_document()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        
-        // Act
-        $response = $this->post(route('documents.store'), [
-            'date' => '2024-01-15',
-            'description' => 'سند نامتوازن',
-            'transactions' => [
-                [
-                    'subject_id' => $this->cashAccount->id,
-                    'debit_amount' => 100000,
-                    'credit_amount' => 0
-                ],
-                [
-                    'subject_id' => $this->salesAccount->id,
-                    'debit_amount' => 0,
-                    'credit_amount' => 50000  // عدم موازنه
-                ]
-            ]
-        ]);
-        
-        // Assert
-        $response->assertSessionHasErrors();
-        $this->assertDatabaseMissing('documents', [
-            'description' => 'سند نامتوازن'
-        ]);
-    }
-    
-    public function test_user_can_view_document_list()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        Document::factory()->count(5)->create([
-            'company_id' => $this->company->id
-        ]);
-        
-        // Act
-        $response = $this->get(route('documents.index'));
-        
-        // Assert
-        $response->assertOk();
-        $response->assertViewIs('documents.index');
-        $response->assertViewHas('documents');
-    }
-    
-    public function test_user_can_search_documents_by_number()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        $targetDocument = Document::factory()->create([
-            'number' => 1001,
-            'company_id' => $this->company->id
-        ]);
-        Document::factory()->create([
-            'number' => 1002,
-            'company_id' => $this->company->id
-        ]);
-        
-        // Act
-        $response = $this->get(route('documents.index', ['number' => 1001]));
-        
-        // Assert
-        $response->assertOk();
-        $response->assertSee($targetDocument->description);
-    }
-}
-```
-
-### 3. Integration Tests
-تست‌های یکپارچگی برای تست ارتباط بین کامپوننت‌ها:
-
-```php
-<?php
-namespace Tests\Integration;
-
-use App\Models\User;
-use App\Models\Subject;
-use App\Models\Document;
-use App\Models\Transaction;
-use App\Services\ReportService;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class ReportGenerationTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    public function test_ledger_report_calculates_account_balance_correctly()
-    {
-        // Arrange
-        $account = Subject::factory()->create(['type' => 'asset']);
-        
-        // ایجاد چند تراکنش
-        Transaction::factory()->create([
-            'subject_id' => $account->id,
-            'debit_amount' => 100000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'subject_id' => $account->id,
-            'debit_amount' => 50000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'subject_id' => $account->id,
-            'debit_amount' => 0,
-            'credit_amount' => 30000
-        ]);
-        
-        // Act
-        $balance = ReportService::calculateAccountBalance($account->id);
-        
-        // Assert
-        $this->assertEquals(120000, $balance); // 100000 + 50000 - 30000
-    }
-}
-```
-
-## 🏭 تست سرویس‌ها
-
-### تست DocumentService
-
-```php
-<?php
-namespace Tests\Unit\Services;
-
-use App\Models\User;
-use App\Models\Subject;
-use App\Models\Company;
-use App\Models\FiscalYear;
-use App\Services\DocumentService;
-use App\Exceptions\DocumentServiceException;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class DocumentServiceTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    private User $user;
-    private Company $company;
-    private Subject $cashAccount;
-    private Subject $salesAccount;
-    
-    protected function setUp(): void
-    {
-        parent::setUp();
-        
-        $this->user = User::factory()->create();
-        $this->company = Company::factory()->create();
-        
-        $this->cashAccount = Subject::factory()->create(['type' => 'asset']);
-        $this->salesAccount = Subject::factory()->create(['type' => 'income']);
-        
-        session(['active-company-id' => $this->company->id]);
-    }
-    
-    public function test_creates_document_with_auto_number()
-    {
-        // Arrange
-        $documentData = [
-            'date' => '2024-01-01',
-            'description' => 'تست'
-        ];
-        
-        $transactions = [
-            [
-                'subject_id' => $this->cashAccount->id,
-                'debit_amount' => 100000,
-                'credit_amount' => 0,
-                'description' => 'بدهکار'
-            ],
-            [
-                'subject_id' => $this->salesAccount->id,
-                'debit_amount' => 0,
-                'credit_amount' => 100000,
-                'description' => 'بستانکار'
-            ]
-        ];
-        
-        // Act
-        $document = DocumentService::createDocument($this->user, $documentData, $transactions);
-        
-        // Assert
-        $this->assertNotNull($document->number);
-        $this->assertEquals(1, $document->number); // اولین سند
-        $this->assertCount(2, $document->transactions);
-    }
-    
-    public function test_throws_exception_for_invalid_subject()
-    {
-        // Arrange
-        $documentData = [
-            'date' => '2024-01-01',
-            'description' => 'تست'
-        ];
-        
-        $transactions = [
-            [
-                'subject_id' => 99999, // سرفصل غیرموجود
-                'debit_amount' => 100000,
-                'credit_amount' => 0
-            ]
-        ];
-        
-        // Act & Assert
-        $this->expectException(DocumentServiceException::class);
-        DocumentService::createDocument($this->user, $documentData, $transactions);
-    }
-}
-```
-
-### تست FiscalYearService
-
-```php
-<?php
-namespace Tests\Unit\Services;
-
-use App\Models\Company;
-use App\Models\FiscalYear;
-use App\Models\Subject;
-use App\Models\Customer;
-use App\Services\FiscalYearService;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class FiscalYearServiceTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    public function test_exports_fiscal_year_data()
-    {
-        // Arrange
-        $company = Company::factory()->create();
-        $fiscalYear = FiscalYear::factory()->create(['company_id' => $company->id]);
-        
-        // ایجاد داده‌های نمونه
-        Subject::factory()->count(5)->create(['company_id' => $company->id]);
-        Customer::factory()->count(3)->create(['company_id' => $company->id]);
-        
-        // Act
-        $exportedData = FiscalYearService::exportData($fiscalYear->id, ['subjects', 'customers']);
-        
-        // Assert
-        $this->assertArrayHasKey('subjects', $exportedData);
-        $this->assertArrayHasKey('customers', $exportedData);
-        $this->assertCount(5, $exportedData['subjects']);
-        $this->assertCount(3, $exportedData['customers']);
-    }
-    
-    public function test_imports_data_to_new_fiscal_year()
-    {
-        // Arrange
-        $company = Company::factory()->create();
-        $newFiscalYear = FiscalYear::factory()->create(['company_id' => $company->id]);
-        
-        $importData = [
-            'subjects' => [
-                ['code' => '1.1.1', 'title' => 'نقد', 'type' => 'asset'],
-                ['code' => '4.1.1', 'title' => 'فروش', 'type' => 'income']
-            ]
-        ];
-        
-        // Act
-        FiscalYearService::importData($newFiscalYear->id, $importData);
-        
-        // Assert
-        $this->assertDatabaseHas('subjects', [
-            'code' => '1.1.1',
-            'title' => 'نقد',
-            'company_id' => $company->id
-        ]);
-    }
-}
-```
-
-## 🎭 استفاده از Factory و Seeder در تست‌ها
-
-### ایجاد Factory
-
-```php
-<?php
-namespace Database\Factories;
-
-use App\Models\Document;
-use App\Models\Company;
-use App\Models\FiscalYear;
-use App\Models\User;
-use Illuminate\Database\Eloquent\Factories\Factory;
-
-class DocumentFactory extends Factory
-{
-    protected $model = Document::class;
-    
-    public function definition(): array
-    {
-        return [
-            'number' => $this->faker->unique()->numberBetween(1000, 9999),
-            'date' => $this->faker->date(),
-            'description' => $this->faker->sentence(),
-            'company_id' => Company::factory(),
-            'fiscal_year_id' => FiscalYear::factory(),
-            'creator_id' => User::factory(),
-        ];
-    }
-    
-    public function forCompany(Company $company): self
-    {
-        return $this->state(function () use ($company) {
-            return [
-                'company_id' => $company->id,
-                'fiscal_year_id' => FiscalYear::factory()->create([
-                    'company_id' => $company->id
-                ])->id
-            ];
-        });
-    }
-    
-    public function withTransactions(int $count = 2): self
-    {
-        return $this->afterCreating(function (Document $document) use ($count) {
-            $amount = 100000;
-            
-            // ایجاد تراکنش‌های متوازن
-            Transaction::factory()->create([
-                'document_id' => $document->id,
-                'debit_amount' => $amount,
-                'credit_amount' => 0
-            ]);
-            
-            Transaction::factory()->create([
-                'document_id' => $document->id,
-                'debit_amount' => 0,
-                'credit_amount' => $amount
-            ]);
-        });
-    }
-}
-```
-
-### استفاده از Factory در تست
-
-```php
-public function test_document_with_transactions()
-{
-    // ایجاد سند با تراکنش‌های متوازن
-    $document = Document::factory()
-        ->forCompany($this->company)
-        ->withTransactions()
-        ->create();
-    
-    $this->assertTrue($document->is_balanced);
-}
-```
-
-## 🗃️ تست مدل‌ها
-
-### تست Relations
-
-```php
-<?php
-namespace Tests\Unit\Models;
-
-use App\Models\Document;
-use App\Models\Transaction;
-use App\Models\Subject;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class DocumentModelTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    public function test_document_has_many_transactions()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        Transaction::factory()->count(3)->create([
-            'document_id' => $document->id
-        ]);
-        
-        // Act & Assert
-        $this->assertCount(3, $document->transactions);
-    }
-    
-    public function test_document_belongs_to_fiscal_year()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        
-        // Act & Assert
-        $this->assertInstanceOf(FiscalYear::class, $document->fiscalYear);
-    }
-    
-    public function test_calculates_total_debit_correctly()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 100000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 50000,
-            'credit_amount' => 0
-        ]);
-        
-        // Act
-        $totalDebit = $document->total_debit;
-        
-        // Assert
-        $this->assertEquals(150000, $totalDebit);
-    }
-    
-    public function test_is_balanced_attribute_works()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        
-        // تراکنش‌های متوازن
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 100000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 0,
-            'credit_amount' => 100000
-        ]);
-        
-        // Act & Assert
-        $this->assertTrue($document->is_balanced);
-    }
-}
-```
-
-### تست Scopes
-
-```php
-public function test_for_fiscal_year_scope()
-{
-    // Arrange
-    $fiscalYear1 = FiscalYear::factory()->create();
-    $fiscalYear2 = FiscalYear::factory()->create();
-    
-    Document::factory()->create(['fiscal_year_id' => $fiscalYear1->id]);
-    Document::factory()->create(['fiscal_year_id' => $fiscalYear1->id]);
-    Document::factory()->create(['fiscal_year_id' => $fiscalYear2->id]);
-    
-    // Act
-    $documentsInFiscalYear1 = Document::forFiscalYear($fiscalYear1->id)->get();
-    
-    // Assert
-    $this->assertCount(2, $documentsInFiscalYear1);
-}
-```
-
-## 🌐 تست Controller ها
-
-### تست Authorization
-
-```php
-public function test_guest_cannot_access_documents()
-{
-    // Act
-    $response = $this->get(route('documents.index'));
-    
-    // Assert
-    $response->assertRedirect(route('login'));
-}
-
-public function test_user_cannot_access_other_company_documents()
-{
-    // Arrange
-    $user = User::factory()->create();
-    $otherCompany = Company::factory()->create();
-    $document = Document::factory()->create([
-        'company_id' => $otherCompany->id
-    ]);
-    
-    // Act
-    $this->actingAs($user);
-    $response = $this->get(route('documents.show', $document));
-    
-    // Assert
-    $response->assertForbidden();
-}
-```
-
-### تست Validation
-
-```php
-public function test_document_creation_requires_valid_data()
-{
-    // Arrange
-    $this->actingAs($this->user);
-    
-    // Act
-    $response = $this->post(route('documents.store'), [
-        'date' => 'invalid-date',
-        'transactions' => []
-    ]);
-    
-    // Assert
-    $response->assertSessionHasErrors(['date', 'transactions']);
-}
-```
-
-## ⚡ Performance Testing
-
-### تست کارایی کوئری‌ها
-
-```php
-public function test_document_list_does_not_have_n_plus_one_problem()
-{
-    // Arrange
-    Document::factory()
-        ->withTransactions()
-        ->count(10)
-        ->create();
-    
-    // Act & Assert
-    $this->assertDatabaseQueriesCount(3, function () {
-        Document::with('transactions', 'creator')->get();
-    });
-}
-```
-
-## 🏃‍♂️ اجرای تست‌ها
-
-### دستورات پایه
+این فایل‌ها نقطه‌ی شروع خوبی برای توسعه‌ی تست‌های جدید هستند. می‌توانید آن‌ها را بازنویسی کنید یا با دستورهای artisan تست‌های تازه بسازید.
 
 ```bash
-# Run all test
-php artisan test
-
-# اجرای تست‌های خاص
-php artisan test --testsuite=Unit
-php artisan test --testsuite=Feature
-
-# اجرای تست‌های یک کلاس خاص
-php artisan test tests/Feature/DocumentTest.php
-
-# اجرای یک تست خاص
-php artisan test --filter test_user_can_create_document
-
-# اجرای با گزارش Coverage
-php artisan test --coverage
-
-# اجرای با جزئیات بیشتر
-php artisan test --verbose
+php artisan make:test DocumentControllerTest
+php artisan make:test DocumentServiceTest --unit
 ```
 
-### تنظیمات محیط تست
+## ▶️ اجرای تست‌ها
 
-```php
-APP_ENV=testing
+برای اجرای تست‌ها می‌توانید از دستورهای متداول زیر استفاده کنید:
+
+```bash
+php artisan test                        # اجرای همه‌ی تست‌ها
+php artisan test --testsuite=Feature    # فقط تست‌های فیچر
+php artisan test --testsuite=Unit       # فقط تست‌های واحد
+php artisan test --filter=Document      # فیلتر کردن بر اساس نام کلاس یا متد
+```
+
+در صورت نیاز به دیتابیس سریع می‌توانید در فایل `.env.testing` از SQLite در حافظه استفاده کنید:
+
+```env
 DB_CONNECTION=sqlite
 DB_DATABASE=:memory:
-CACHE_DRIVER=array
-SESSION_DRIVER=array
-QUEUE_CONNECTION=sync
 ```
 
-## 🔧 ابزارهای کمکی تست
+## 🚀 گسترش تست‌های فیچر
 
-### Custom Assertions
+برای سناریوهای HTTP از `Tests\TestCase` به همراه traits لاراول استفاده کنید. نمونه‌ی زیر نشان می‌دهد چگونه می‌توانید از تست نمونه برای بررسی دسترسی به لیست اسناد استفاده کنید:
 
 ```php
 <?php
-namespace Tests;
 
-use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+namespace Tests\Feature;
 
-abstract class TestCase extends BaseTestCase
-{
-    use CreatesApplication;
-    
-    protected function assertDocumentIsBalanced($document)
-    {
-        $this->assertEquals(
-            $document->total_debit,
-            $document->total_credit,
-            'سند متوازن نیست'
-        );
-    }
-    
-    protected function assertAccountBalance($accountId, $expectedBalance)
-    {
-        $actualBalance = Transaction::where('subject_id', $accountId)
-            ->sum(DB::raw('debit_amount - credit_amount'));
-            
-        $this->assertEquals(
-            $expectedBalance,
-            $actualBalance,
-            "مانده حساب با مقدار مورد انتظار برابر نیست"
-        );
-    }
-}
-```
-
-### Test Traits
-
-```php
-<?php
-namespace Tests\Traits;
-
-use App\Models\User;
 use App\Models\Company;
-use App\Models\FiscalYear;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
-trait SetsUpTestData
+class DocumentAccessTest extends TestCase
 {
-    protected function setUpTestCompany(): Company
-    {
-        $company = Company::factory()->create();
-        $fiscalYear = FiscalYear::factory()->create([
-            'company_id' => $company->id
-        ]);
-        
-        session(['active-company-id' => $company->id]);
-        
-        return $company;
-    }
-    
-    protected function actingAsUser($permissions = []): User
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_documents_index(): void
     {
         $user = User::factory()->create();
-        
-        if (!empty($permissions)) {
-            $user->givePermissionTo($permissions);
-        }
-        
+        $company = Company::factory()->create();
+
+        session(['active-company-id' => $company->id]);
+
         $this->actingAs($user);
-        
-        return $user;
+        $this->withoutMiddleware('check-permission');
+
+        $response = $this->get('/documents');
+
+        $response->assertOk();
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $response = $this->get('/documents');
+
+        $response->assertRedirect('/login');
     }
 }
 ```
 
-## 📊 تست گزارش‌ها
+نکته‌ها:
+- بسیاری از مدل‌ها از `FiscalYearScope` استفاده می‌کنند و انتظار دارند شناسه‌ی شرکت فعال در session موجود باشد (`session(['active-company-id' => ...])`).
+- در صورت نیاز می‌توانید با `$this->withoutMiddleware()` برخی middlewareها مثل `check-permission` را غیرفعال کنید تا روی منطق اصلی تمرکز کنید.
+
+## 🧩 نمونه‌ی تست واحد برای سرویس‌ها
+
+برای تست متدهای موجود در `App\Services\DocumentService` می‌توانید از دیتابیس تست به همراه factoryها استفاده کنید. مثال زیر متد `createTransaction` را بررسی می‌کند:
 
 ```php
-public function test_ledger_report_accuracy()
-{
-    // Arrange
-    $account = Subject::factory()->create(['type' => 'asset']);
-    
-    // ایجاد تراکنش‌های مختلف
-    $this->createTransaction($account, 100000, 0); // +100000
-    $this->createTransaction($account, 50000, 0);  // +50000
-    $this->createTransaction($account, 0, 30000);  // -30000
-    
-    // Act
-    $ledgerData = app(ReportService::class)->generateLedger($account->id);
-    
-    // Assert
-    $this->assertEquals(120000, $ledgerData['final_balance']);
-    $this->assertCount(3, $ledgerData['transactions']);
-}
+<?php
 
-private function createTransaction($account, $debit, $credit)
+namespace Tests\Unit;
+
+use App\Models\Company;
+use App\Models\Document;
+use App\Models\Subject;
+use App\Models\User;
+use App\Services\DocumentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DocumentServiceTest extends TestCase
 {
-    $document = Document::factory()->create();
-    
-    Transaction::create([
-        'document_id' => $document->id,
-        'subject_id' => $account->id,
-        'debit_amount' => $debit,
-        'credit_amount' => $credit,
-        'description' => 'تراکنش تست'
-    ]);
+    use RefreshDatabase;
+
+    public function test_create_transaction_persists_value(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create();
+        $subject = Subject::factory()->create();
+
+        session(['active-company-id' => $company->id]);
+
+        $document = Document::factory()->create([
+            'company_id' => $company->id,
+            'creator_id' => $user->id,
+        ]);
+
+        $transaction = DocumentService::createTransaction($document, [
+            'subject_id' => $subject->id,
+            'desc' => 'ثبت خرید کالا',
+            'value' => '120000.00',
+        ]);
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $transaction->id,
+            'document_id' => $document->id,
+            'subject_id' => $subject->id,
+        ]);
+    }
 }
 ```
 
----
+اگر قصد تست سایر متدها مانند `createDocument` یا `updateDocumentTransactions` را دارید می‌توانید از همین الگو بهره بگیرید و با factoryهای موجود داده‌ی اولیه بسازید.
 
-**نکته مهم**: همیشه قبل از commit کردن تغییرات، تمام تست‌ها را اجرا کنید و مطمئن شوید که همه موفق هستند. در سیستم‌های مالی، هیچ تست شکست خورده‌ای نباید نادیده گرفته شود.
+## 🏭 کار با Factory ها
+
+Factoryهای زیر در مسیر `database/factories` برای ایجاد داده‌های تستی در دسترس هستند:
+
+- `CompanyFactory`
+- `UserFactory`
+- `SubjectFactory`
+- `DocumentFactory`
+- `TransactionFactory`
+- `CustomerFactory`، `ProductFactory` و سایر factoryهای مرتبط با ماژول‌های فروش
+
+پیش از استفاده از `DocumentFactory` مطمئن شوید حداقل یک شرکت و کاربر ایجاد کرده‌اید؛ این factory برای مقداردهی شناسه‌ها از رکوردهای موجود استفاده می‌کند.
+
+نمونه‌ی استفاده در تست:
+
+```php
+$company = Company::factory()->create();
+$user = User::factory()->create();
+
+session(['active-company-id' => $company->id]);
+
+$document = Document::factory()->create([
+    'company_id' => $company->id,
+    'creator_id' => $user->id,
+]);
+```
+
+## 💡 نکات تکمیلی
+
+- از trait `RefreshDatabase` برای ریست دیتابیس بین تست‌ها استفاده کنید.
+- برای تست متدهایی که به تاریخ یا زمان متکی‌اند می‌توانید از متد `Carbon::setTestNow()` کمک بگیرید.
+- اگر نیاز به داده‌های نمونه دارید، می‌توانید از seederهای موجود استفاده کرده یا seeder مخصوص تست بسازید و در متد `setUp` اجرا کنید.
+
+با دنبال کردن این الگوها می‌توانید تست‌های موجود را از حالت نمونه خارج کرده و به مرور پوشش قابل اعتمادی برای پروژه ایجاد کنید.


### PR DESCRIPTION
## Summary
- refresh the project structure guide to describe the current Eloquent models, API route stub, tests folder layout, and the actual `documents` table schema
- rewrite the testing guide so it reflects the existing placeholder tests and explains how to extend them using the available services and factories

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ce7fbaafd0832a95353fb3b3dc22ea