### PR TITLE
Update testing guide to match current accounting services

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -1,735 +1,322 @@
 # راهنمای تست در امیر
 
-این راهنما نحوه نوشتن و اجرای تست‌ها در پروژه امیر را توضیح می‌دهد.
+این راهنما نسخه‌ای به‌روز از شیوه‌ی تست‌نویسی در پروژه امیر است. تمام مثال‌ها بر اساس کد فعلی نوشته شده‌اند و از سرویس‌های واقعی موجود در مخزن استفاده می‌کنند. اگر بخشی از قابلیت‌ها هنوز پیاده‌سازی نشده باشد (مثلاً helperهای محاسبه مانده)، در این راهنما به‌عنوان «کارهای آینده» مشخص شده‌اند تا با کد موجود اشتباه گرفته نشوند.
 
-## 🎯 اهمیت تست در سیستم‌های مالی
+## مفاهیم پایه قبل از نوشتن تست
 
-در سیستم‌های حسابداری، تست‌نویسی بسیار حیاتی است زیرا:
-- خطاهای محاسباتی می‌توانند باعث عدم تطبیق حساب‌ها شوند
-- منطق حسابداری پیچیده و مستعد خطا است
-- تغییرات کوچک می‌توانند تأثیرات گسترده داشته باشند
-- قوانین مالیاتی و حسابداری باید دقیقاً رعایت شوند
+### سرویس سند (`DocumentService`)
+`DocumentService` منبع اصلی منطق حسابداری در لایهٔ سرویس است. متدهای در دسترس آن عبارت‌اند از:
 
-## 🧪 انواع تست در امیر
+- `createDocument(User $user, array $data, array $transactions)` – ایجاد سند جدید و ثبت تراکنش‌ها در یک تراکنش دیتابیس. این متد شماره‌ی سند را در صورت نبودن مقدار ورودی به‌طور خودکار تولید می‌کند و خطاهای ولیدیشن را از طریق `DocumentServiceException` برمی‌گرداند.【F:app/Services/DocumentService.php†L15-L57】
+- `updateDocument(Document $document, array $data)` – به‌روزرسانی فیلدهای ساده‌ی سند (شماره، تاریخ، عنوان). برای خطاهای ولیدیشن از استثناء عمومی (`\Exception`) استفاده می‌شود.【F:app/Services/DocumentService.php†L59-L92】
+- `approveDocument(Document $document)` – بررسی می‌کند مجموع فیلد `value` در تمام تراکنش‌های سند صفر باشد و سپس `approved_at` را مقداردهی می‌کند. در صورت عدم موازنه، استثناء پرتاب می‌شود.【F:app/Services/DocumentService.php†L94-L117】
+- `createTransaction(Document $document, array $data)` و `updateTransaction(Transaction $transaction, array $data)` – ولیدیشن تراکنش‌ها را با فیلدهای `subject_id`, `desc`, `value` انجام می‌دهند و مقدار را در جدول `transactions` ذخیره می‌کنند.【F:app/Services/DocumentService.php†L119-L161】
+- `updateDocumentTransactions(int $documentId, array $transactionsData)` – داده‌های دریافتی از فرم را که شامل ستون‌های `debit` و `credit` است به مقدار واحد `value` تبدیل می‌کند و رکوردها را به‌روزرسانی می‌کند.【F:app/Services/DocumentService.php†L163-L187】
+- `deleteDocument(int $documentId)` – حذف سند و تراکنش‌های مرتبط در یک تراکنش دیتابیس.【F:app/Services/DocumentService.php†L189-L198】
 
-### 1. Unit Tests
-تست‌های واحد برای تست منطق کلاس‌ها و متدهای مجزا:
+### ساختار تراکنش‌ها و تبدیل «بدهکار/بستانکار»
+- در جدول `transactions` تنها یک ستون `value` نگه‌داری می‌شود؛ مقدار مثبت به معنای «بستانکار» و مقدار منفی به معنای «بدهکار» است. مدل `Transaction` همین منطق را برای نمایش فیلدهای مجازی `debit` و `credit` استفاده می‌کند.【F:app/Models/Transaction.php†L11-L44】
+- درخواست‌های ایجاد/ویرایش سند توسط `StoreTransactionRequest` اعتبارسنجی می‌شوند. این کلاس پیش از ولیدیشن، مقادیر ورودی `debit` و `credit` را به اعداد اعشاری تبدیل می‌کند و سپس قواعدی مانند «حداقل یکی از بدهکار یا بستانکار باید پر باشد» را اعمال می‌کند.【F:app/Http/Requests/StoreTransactionRequest.php†L23-L71】
+- هنگام ساخت داده‌ی تست برای سرویس‌ها، اگر قصد دارید به‌صورت مستقیم `DocumentService::createTransaction` را صدا بزنید باید خودتان مقدار `value` را محاسبه و ارسال کنید. در تست‌های لایهٔ HTTP می‌توانید آرایه‌ی `transactions` را همانند فرم با کلیدهای `debit`, `credit`, `desc`, `subject_id` بسازید تا request آن را آماده کند.
 
+> **نکته:** وجود scope سراسری `FiscalYearScope` روی مدل‌های `Document` و `Subject` باعث می‌شود تمام کوئری‌ها به شناسهٔ شرکت فعال (`session('active-company-id')`) فیلتر شوند. پیش از اجرای تست‌هایی که این مدل‌ها را لمس می‌کنند، حتماً مقدار session را تنظیم کنید.【F:app/Models/Scopes/FiscalYearScope.php†L8-L16】
+
+## Unit Test‌ها
+
+نمونه‌های زیر در پوشه‌ی `tests/Unit/Services` قابل‌استفاده هستند و همگی از `RefreshDatabase` برای بازیابی دیتابیس استفاده می‌کنند.
+
+### ایجاد سند و ذخیرهٔ تراکنش‌ها
 ```php
 <?php
-namespace Tests\Unit;
 
-use App\Services\DocumentService;
-use App\Exceptions\DocumentServiceException;
-use PHPUnit\Framework\TestCase;
-
-class DocumentServiceTest extends TestCase
-{
-    public function test_calculates_document_balance_correctly()
-    {
-        // Arrange
-        $transactions = [
-            ['debit_amount' => 100000, 'credit_amount' => 0],
-            ['debit_amount' => 0, 'credit_amount' => 100000]
-        ];
-        
-        // Act
-        $isBalanced = DocumentService::isBalanced($transactions);
-        
-        // Assert
-        $this->assertTrue($isBalanced);
-    }
-    
-    public function test_detects_unbalanced_transactions()
-    {
-        // Arrange
-        $transactions = [
-            ['debit_amount' => 100000, 'credit_amount' => 0],
-            ['debit_amount' => 0, 'credit_amount' => 50000]
-        ];
-        
-        // Act
-        $isBalanced = DocumentService::isBalanced($transactions);
-        
-        // Assert
-        $this->assertFalse($isBalanced);
-    }
-    
-    public function test_validates_transaction_amounts()
-    {
-        // Arrange
-        $invalidTransactions = [
-            ['debit_amount' => -100, 'credit_amount' => 0]
-        ];
-        
-        // Act & Assert
-        $this->expectException(DocumentServiceException::class);
-        $this->expectExceptionMessage('مبلغ نمی‌تواند منفی باشد');
-        
-        DocumentService::validateTransactions($invalidTransactions);
-    }
-}
-```
-
-### 2. Feature Tests
-تست‌های عملکردی برای تست کل workflow:
-
-```php
-<?php
-namespace Tests\Feature;
-
-use App\Models\User;
-use App\Models\Subject;
-use App\Models\Document;
-use App\Models\Company;
-use App\Models\FiscalYear;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class DocumentManagementTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    private User $user;
-    private Company $company;
-    private FiscalYear $fiscalYear;
-    private Subject $cashAccount;
-    private Subject $salesAccount;
-    
-    protected function setUp(): void
-    {
-        parent::setUp();
-        
-        // ایجاد داده‌های مورد نیاز برای تست
-        $this->user = User::factory()->create();
-        $this->company = Company::factory()->create();
-        $this->fiscalYear = FiscalYear::factory()->create([
-            'company_id' => $this->company->id
-        ]);
-        
-        $this->cashAccount = Subject::factory()->create([
-            'type' => 'asset',
-            'code' => '1.1.1.001',
-            'title' => 'صندوق'
-        ]);
-        
-        $this->salesAccount = Subject::factory()->create([
-            'type' => 'income',
-            'code' => '4.1.1.001',
-            'title' => 'فروش'
-        ]);
-        
-        // تنظیم session برای شرکت فعال
-        session(['active-company-id' => $this->company->id]);
-    }
-    
-    public function test_user_can_create_document_via_form()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        
-        // Act
-        $response = $this->post(route('documents.store'), [
-            'date' => '2024-01-15',
-            'description' => 'فروش نقدی کالا',
-            'transactions' => [
-                [
-                    'subject_id' => $this->cashAccount->id,
-                    'debit_amount' => 100000,
-                    'credit_amount' => 0,
-                    'description' => 'دریافت وجه نقد'
-                ],
-                [
-                    'subject_id' => $this->salesAccount->id,
-                    'debit_amount' => 0,
-                    'credit_amount' => 100000,
-                    'description' => 'درآمد فروش'
-                ]
-            ]
-        ]);
-        
-        // Assert
-        $response->assertRedirect();
-        $response->assertSessionHas('success');
-        
-        $this->assertDatabaseHas('documents', [
-            'description' => 'فروش نقدی کالا',
-            'company_id' => $this->company->id
-        ]);
-        
-        $document = Document::where('description', 'فروش نقدی کالا')->first();
-        $this->assertCount(2, $document->transactions);
-        $this->assertEquals(100000, $document->total_debit);
-        $this->assertEquals(100000, $document->total_credit);
-        $this->assertTrue($document->is_balanced);
-    }
-    
-    public function test_cannot_create_unbalanced_document()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        
-        // Act
-        $response = $this->post(route('documents.store'), [
-            'date' => '2024-01-15',
-            'description' => 'سند نامتوازن',
-            'transactions' => [
-                [
-                    'subject_id' => $this->cashAccount->id,
-                    'debit_amount' => 100000,
-                    'credit_amount' => 0
-                ],
-                [
-                    'subject_id' => $this->salesAccount->id,
-                    'debit_amount' => 0,
-                    'credit_amount' => 50000  // عدم موازنه
-                ]
-            ]
-        ]);
-        
-        // Assert
-        $response->assertSessionHasErrors();
-        $this->assertDatabaseMissing('documents', [
-            'description' => 'سند نامتوازن'
-        ]);
-    }
-    
-    public function test_user_can_view_document_list()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        Document::factory()->count(5)->create([
-            'company_id' => $this->company->id
-        ]);
-        
-        // Act
-        $response = $this->get(route('documents.index'));
-        
-        // Assert
-        $response->assertOk();
-        $response->assertViewIs('documents.index');
-        $response->assertViewHas('documents');
-    }
-    
-    public function test_user_can_search_documents_by_number()
-    {
-        // Arrange
-        $this->actingAs($this->user);
-        $targetDocument = Document::factory()->create([
-            'number' => 1001,
-            'company_id' => $this->company->id
-        ]);
-        Document::factory()->create([
-            'number' => 1002,
-            'company_id' => $this->company->id
-        ]);
-        
-        // Act
-        $response = $this->get(route('documents.index', ['number' => 1001]));
-        
-        // Assert
-        $response->assertOk();
-        $response->assertSee($targetDocument->description);
-    }
-}
-```
-
-### 3. Integration Tests
-تست‌های یکپارچگی برای تست ارتباط بین کامپوننت‌ها:
-
-```php
-<?php
-namespace Tests\Integration;
-
-use App\Models\User;
-use App\Models\Subject;
-use App\Models\Document;
-use App\Models\Transaction;
-use App\Services\ReportService;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class ReportGenerationTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    public function test_ledger_report_calculates_account_balance_correctly()
-    {
-        // Arrange
-        $account = Subject::factory()->create(['type' => 'asset']);
-        
-        // ایجاد چند تراکنش
-        Transaction::factory()->create([
-            'subject_id' => $account->id,
-            'debit_amount' => 100000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'subject_id' => $account->id,
-            'debit_amount' => 50000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'subject_id' => $account->id,
-            'debit_amount' => 0,
-            'credit_amount' => 30000
-        ]);
-        
-        // Act
-        $balance = ReportService::calculateAccountBalance($account->id);
-        
-        // Assert
-        $this->assertEquals(120000, $balance); // 100000 + 50000 - 30000
-    }
-}
-```
-
-## 🏭 تست سرویس‌ها
-
-### تست DocumentService
-
-```php
-<?php
 namespace Tests\Unit\Services;
 
-use App\Models\User;
-use App\Models\Subject;
-use App\Models\Company;
-use App\Models\FiscalYear;
-use App\Services\DocumentService;
 use App\Exceptions\DocumentServiceException;
+use App\Models\Document;
+use App\Models\Company;
+use App\Models\Subject;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\DocumentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class DocumentServiceTest extends TestCase
 {
     use RefreshDatabase;
-    
-    private User $user;
-    private Company $company;
-    private Subject $cashAccount;
-    private Subject $salesAccount;
-    
-    protected function setUp(): void
+
+    public function test_create_document_persists_transactions(): void
     {
-        parent::setUp();
-        
-        $this->user = User::factory()->create();
-        $this->company = Company::factory()->create();
-        
-        $this->cashAccount = Subject::factory()->create(['type' => 'asset']);
-        $this->salesAccount = Subject::factory()->create(['type' => 'income']);
-        
-        session(['active-company-id' => $this->company->id]);
-    }
-    
-    public function test_creates_document_with_auto_number()
-    {
-        // Arrange
-        $documentData = [
-            'date' => '2024-01-01',
-            'description' => 'تست'
-        ];
-        
-        $transactions = [
+        $company = Company::factory()->create();
+        session(['active-company-id' => $company->id]);
+
+        $user = User::factory()->create();
+        $cash = Subject::factory()->create(['company_id' => $company->id]);
+        $revenue = Subject::factory()->create(['company_id' => $company->id]);
+
+        $document = DocumentService::createDocument($user, [
+            'title' => 'سند فروش',
+            'date' => now()->toDateString(),
+        ], [
             [
-                'subject_id' => $this->cashAccount->id,
-                'debit_amount' => 100000,
-                'credit_amount' => 0,
-                'description' => 'بدهکار'
+                'subject_id' => $cash->id,
+                'value' => '-150000.00',
+                'desc' => 'دریافت وجه نقد',
             ],
             [
-                'subject_id' => $this->salesAccount->id,
-                'debit_amount' => 0,
-                'credit_amount' => 100000,
-                'description' => 'بستانکار'
-            ]
-        ];
-        
-        // Act
-        $document = DocumentService::createDocument($this->user, $documentData, $transactions);
-        
-        // Assert
-        $this->assertNotNull($document->number);
-        $this->assertEquals(1, $document->number); // اولین سند
+                'subject_id' => $revenue->id,
+                'value' => '150000.00',
+                'desc' => 'ثبت فروش',
+            ],
+        ]);
+
+        $this->assertEquals($company->id, $document->company_id);
         $this->assertCount(2, $document->transactions);
     }
-    
-    public function test_throws_exception_for_invalid_subject()
-    {
-        // Arrange
-        $documentData = [
-            'date' => '2024-01-01',
-            'description' => 'تست'
-        ];
-        
-        $transactions = [
-            [
-                'subject_id' => 99999, // سرفصل غیرموجود
-                'debit_amount' => 100000,
-                'credit_amount' => 0
-            ]
-        ];
-        
-        // Act & Assert
-        $this->expectException(DocumentServiceException::class);
-        DocumentService::createDocument($this->user, $documentData, $transactions);
-    }
 }
 ```
 
-### تست FiscalYearService
-
+### مدیریت خطاهای ولیدیشن
 ```php
-<?php
-namespace Tests\Unit\Services;
-
-use App\Models\Company;
-use App\Models\FiscalYear;
-use App\Models\Subject;
-use App\Models\Customer;
-use App\Services\FiscalYearService;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class FiscalYearServiceTest extends TestCase
+public function test_create_document_requires_date(): void
 {
-    use RefreshDatabase;
-    
-    public function test_exports_fiscal_year_data()
-    {
-        // Arrange
-        $company = Company::factory()->create();
-        $fiscalYear = FiscalYear::factory()->create(['company_id' => $company->id]);
-        
-        // ایجاد داده‌های نمونه
-        Subject::factory()->count(5)->create(['company_id' => $company->id]);
-        Customer::factory()->count(3)->create(['company_id' => $company->id]);
-        
-        // Act
-        $exportedData = FiscalYearService::exportData($fiscalYear->id, ['subjects', 'customers']);
-        
-        // Assert
-        $this->assertArrayHasKey('subjects', $exportedData);
-        $this->assertArrayHasKey('customers', $exportedData);
-        $this->assertCount(5, $exportedData['subjects']);
-        $this->assertCount(3, $exportedData['customers']);
-    }
-    
-    public function test_imports_data_to_new_fiscal_year()
-    {
-        // Arrange
-        $company = Company::factory()->create();
-        $newFiscalYear = FiscalYear::factory()->create(['company_id' => $company->id]);
-        
-        $importData = [
-            'subjects' => [
-                ['code' => '1.1.1', 'title' => 'نقد', 'type' => 'asset'],
-                ['code' => '4.1.1', 'title' => 'فروش', 'type' => 'income']
-            ]
-        ];
-        
-        // Act
-        FiscalYearService::importData($newFiscalYear->id, $importData);
-        
-        // Assert
-        $this->assertDatabaseHas('subjects', [
-            'code' => '1.1.1',
-            'title' => 'نقد',
-            'company_id' => $company->id
-        ]);
-    }
-}
-```
+    $this->expectException(DocumentServiceException::class);
 
-## 🎭 استفاده از Factory و Seeder در تست‌ها
+    $company = Company::factory()->create();
+    session(['active-company-id' => $company->id]);
 
-### ایجاد Factory
-
-```php
-<?php
-namespace Database\Factories;
-
-use App\Models\Document;
-use App\Models\Company;
-use App\Models\FiscalYear;
-use App\Models\User;
-use Illuminate\Database\Eloquent\Factories\Factory;
-
-class DocumentFactory extends Factory
-{
-    protected $model = Document::class;
-    
-    public function definition(): array
-    {
-        return [
-            'number' => $this->faker->unique()->numberBetween(1000, 9999),
-            'date' => $this->faker->date(),
-            'description' => $this->faker->sentence(),
-            'company_id' => Company::factory(),
-            'fiscal_year_id' => FiscalYear::factory(),
-            'creator_id' => User::factory(),
-        ];
-    }
-    
-    public function forCompany(Company $company): self
-    {
-        return $this->state(function () use ($company) {
-            return [
-                'company_id' => $company->id,
-                'fiscal_year_id' => FiscalYear::factory()->create([
-                    'company_id' => $company->id
-                ])->id
-            ];
-        });
-    }
-    
-    public function withTransactions(int $count = 2): self
-    {
-        return $this->afterCreating(function (Document $document) use ($count) {
-            $amount = 100000;
-            
-            // ایجاد تراکنش‌های متوازن
-            Transaction::factory()->create([
-                'document_id' => $document->id,
-                'debit_amount' => $amount,
-                'credit_amount' => 0
-            ]);
-            
-            Transaction::factory()->create([
-                'document_id' => $document->id,
-                'debit_amount' => 0,
-                'credit_amount' => $amount
-            ]);
-        });
-    }
-}
-```
-
-### استفاده از Factory در تست
-
-```php
-public function test_document_with_transactions()
-{
-    // ایجاد سند با تراکنش‌های متوازن
-    $document = Document::factory()
-        ->forCompany($this->company)
-        ->withTransactions()
-        ->create();
-    
-    $this->assertTrue($document->is_balanced);
-}
-```
-
-## 🗃️ تست مدل‌ها
-
-### تست Relations
-
-```php
-<?php
-namespace Tests\Unit\Models;
-
-use App\Models\Document;
-use App\Models\Transaction;
-use App\Models\Subject;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class DocumentModelTest extends TestCase
-{
-    use RefreshDatabase;
-    
-    public function test_document_has_many_transactions()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        Transaction::factory()->count(3)->create([
-            'document_id' => $document->id
-        ]);
-        
-        // Act & Assert
-        $this->assertCount(3, $document->transactions);
-    }
-    
-    public function test_document_belongs_to_fiscal_year()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        
-        // Act & Assert
-        $this->assertInstanceOf(FiscalYear::class, $document->fiscalYear);
-    }
-    
-    public function test_calculates_total_debit_correctly()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 100000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 50000,
-            'credit_amount' => 0
-        ]);
-        
-        // Act
-        $totalDebit = $document->total_debit;
-        
-        // Assert
-        $this->assertEquals(150000, $totalDebit);
-    }
-    
-    public function test_is_balanced_attribute_works()
-    {
-        // Arrange
-        $document = Document::factory()->create();
-        
-        // تراکنش‌های متوازن
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 100000,
-            'credit_amount' => 0
-        ]);
-        
-        Transaction::factory()->create([
-            'document_id' => $document->id,
-            'debit_amount' => 0,
-            'credit_amount' => 100000
-        ]);
-        
-        // Act & Assert
-        $this->assertTrue($document->is_balanced);
-    }
-}
-```
-
-### تست Scopes
-
-```php
-public function test_for_fiscal_year_scope()
-{
-    // Arrange
-    $fiscalYear1 = FiscalYear::factory()->create();
-    $fiscalYear2 = FiscalYear::factory()->create();
-    
-    Document::factory()->create(['fiscal_year_id' => $fiscalYear1->id]);
-    Document::factory()->create(['fiscal_year_id' => $fiscalYear1->id]);
-    Document::factory()->create(['fiscal_year_id' => $fiscalYear2->id]);
-    
-    // Act
-    $documentsInFiscalYear1 = Document::forFiscalYear($fiscalYear1->id)->get();
-    
-    // Assert
-    $this->assertCount(2, $documentsInFiscalYear1);
-}
-```
-
-## 🌐 تست Controller ها
-
-### تست Authorization
-
-```php
-public function test_guest_cannot_access_documents()
-{
-    // Act
-    $response = $this->get(route('documents.index'));
-    
-    // Assert
-    $response->assertRedirect(route('login'));
-}
-
-public function test_user_cannot_access_other_company_documents()
-{
-    // Arrange
     $user = User::factory()->create();
-    $otherCompany = Company::factory()->create();
+
+    DocumentService::createDocument($user, [
+        'title' => 'بدون تاریخ',
+        // تاریخ ارسال نشده است
+    ], []);
+}
+```
+
+### تبدیل مقادیر بدهکار/بستانکار در به‌روزرسانی
+```php
+public function test_update_document_transactions_converts_debit_and_credit(): void
+{
+    $company = Company::factory()->create();
+    $user = User::factory()->create();
+    session(['active-company-id' => $company->id]);
+
     $document = Document::factory()->create([
-        'company_id' => $otherCompany->id
+        'company_id' => $company->id,
+        'creator_id' => $user->id,
     ]);
-    
-    // Act
-    $this->actingAs($user);
-    $response = $this->get(route('documents.show', $document));
-    
-    // Assert
-    $response->assertForbidden();
+    $subject = Subject::factory()->create(['company_id' => $company->id]);
+
+    DocumentService::updateDocumentTransactions($document->id, [
+        [
+            'transaction_id' => null,
+            'subject_id' => $subject->id,
+            'desc' => 'بدهکار',
+            'debit' => 200000,
+            'credit' => 0,
+        ],
+        [
+            'transaction_id' => null,
+            'subject_id' => $subject->id,
+            'desc' => 'بستانکار',
+            'debit' => 0,
+            'credit' => 200000,
+        ],
+    ]);
+
+    $values = $document->fresh()->transactions()->pluck('value');
+    $this->assertTrue($values->contains(-200000.0));
+    $this->assertTrue($values->contains(200000.0));
 }
 ```
 
-### تست Validation
+### تأیید سند و کنترل موازنه
+```php
+public function test_approve_document_requires_zero_balance(): void
+{
+    $company = Company::factory()->create();
+    $user = User::factory()->create();
+    session(['active-company-id' => $company->id]);
+
+    $document = Document::factory()->create([
+        'company_id' => $company->id,
+        'creator_id' => $user->id,
+    ]);
+
+    $subject = Subject::factory()->create(['company_id' => $company->id]);
+    Transaction::factory()->state([
+        'document_id' => $document->id,
+        'subject_id' => $subject->id,
+        'value' => 50000,
+        'desc' => 'ردیف آزمایشی',
+    ])->create();
+
+    $this->expectException(\Exception::class);
+    DocumentService::approveDocument($document);
+}
+```
+
+> **کارهای آینده:** تابع کمکی برای سنجش موازنه‌ی سند (مثلاً `DocumentService::isBalanced`) فعلاً در کد وجود ندارد. تا زمان پیاده‌سازی، برای تست موازنه باید مجموع `value` تراکنش‌ها را دستی محاسبه کنید یا از خود متد `approveDocument` استفاده کنید.
+
+## Feature Test‌ها (HTTP Layer)
 
 ```php
-public function test_document_creation_requires_valid_data()
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Subject;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DocumentControllerTest extends TestCase
 {
-    // Arrange
-    $this->actingAs($this->user);
-    
-    // Act
-    $response = $this->post(route('documents.store'), [
-        'date' => 'invalid-date',
-        'transactions' => []
-    ]);
-    
-    // Assert
-    $response->assertSessionHasErrors(['date', 'transactions']);
+    use RefreshDatabase;
+
+    public function test_user_can_store_document_via_form(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create();
+        session(['active-company-id' => $company->id]);
+
+        $cash = Subject::factory()->create(['company_id' => $company->id]);
+        $payable = Subject::factory()->create(['company_id' => $company->id]);
+
+        $response = $this->actingAs($user)->post(route('documents.store'), [
+            'title' => 'ثبت سند دستی',
+            'number' => 1001,
+            'date' => now()->format('Y-m-d'),
+            'transactions' => [
+                [
+                    'subject_id' => $cash->id,
+                    'desc' => 'دریافت وجه',
+                    'debit' => 200000,
+                    'credit' => 0,
+                ],
+                [
+                    'subject_id' => $payable->id,
+                    'desc' => 'بستانکار مقابل',
+                    'debit' => 0,
+                    'credit' => 200000,
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('documents', [
+            'title' => 'ثبت سند دستی',
+            'number' => 1001,
+            'company_id' => $company->id,
+        ]);
+
+        $this->assertDatabaseHas('transactions', [
+            'desc' => 'دریافت وجه',
+            'value' => -200000,
+        ]);
+        $this->assertDatabaseHas('transactions', [
+            'desc' => 'بستانکار مقابل',
+            'value' => 200000,
+        ]);
+    }
+
+    public function test_validation_errors_are_reported_back_to_session(): void
+    {
+        $company = Company::factory()->create();
+        $user = User::factory()->create();
+        session(['active-company-id' => $company->id]);
+
+        $response = $this->actingAs($user)->post(route('documents.store'), [
+            'title' => 'سند ناقص',
+            'transactions' => [
+                [
+                    'subject_id' => null,
+                    'desc' => '',
+                    'debit' => null,
+                    'credit' => null,
+                ],
+            ],
+        ]);
+
+        $response->assertSessionHasErrors([
+            'number',
+            'date',
+            'transactions.0.subject_id',
+            'transactions.0.debit',
+            'transactions.0.credit',
+            'transactions.0.desc',
+        ]);
+    }
 }
 ```
 
-## ⚡ Performance Testing
+در مثال بالا داده‌ی ورودی دقیقاً با ساختار فرم واقعی (ولیدیشن `StoreTransactionRequest`) تنظیم شده است؛ بنابراین نیازی به محاسبه‌ی دستی مقدار `value` نیست و سرویس خودش آن را محاسبه و ذخیره می‌کند.【F:app/Http/Controllers/DocumentController.php†L41-L90】
 
-### تست کارایی کوئری‌ها
+## استفاده از Factoryها در تست
+
+### `DocumentFactory`
+- این فکتوری شماره‌ی سند را با `DB::table('documents')->max('number') + 1` محاسبه می‌کند و از بین شرکت‌ها و کاربران موجود یکی را انتخاب می‌کند.【F:database/factories/DocumentFactory.php†L18-L27】
+- قبل از فراخوانی `Document::factory()` مطمئن شوید حداقل یک رکورد در جداول `companies` و `users` وجود داشته باشد؛ در غیر این صورت فراخوانی `random()` خطا می‌دهد.
+- برای کنترل دقیق‌تر می‌توانید state اختصاصی بدهید:
 
 ```php
-public function test_document_list_does_not_have_n_plus_one_problem()
-{
-    // Arrange
-    Document::factory()
-        ->withTransactions()
-        ->count(10)
-        ->create();
-    
-    // Act & Assert
-    $this->assertDatabaseQueriesCount(3, function () {
-        Document::with('transactions', 'creator')->get();
-    });
-}
+$company = Company::factory()->create();
+$user = User::factory()->create();
+
+session(['active-company-id' => $company->id]);
+
+$document = Document::factory()->create([
+    'company_id' => $company->id,
+    'creator_id' => $user->id,
+    'title' => 'سند آزمایشی',
+]);
 ```
 
-## 🏃‍♂️ اجرای تست‌ها
+### `TransactionFactory`
+- پیاده‌سازی فعلی مقدار پیش‌فرضی برنمی‌گرداند و یک آرایه‌ی خالی تحویل می‌دهد.【F:database/factories/TransactionFactory.php†L15-L19】 بنابراین هنگام استفاده باید تمام ستون‌های لازم را از طریق `state` یا آرایه‌ی ورودی مشخص کنید.
+- یک الگوی متداول برای ایجاد تراکنش متوازن به شکل زیر است:
 
-### دستورات پایه
+```php
+Transaction::factory()->state([
+    'document_id' => $document->id,
+    'subject_id' => $cash->id,
+    'value' => -50000,
+    'desc' => 'بدهکار',
+])->create();
+
+Transaction::factory()->state([
+    'document_id' => $document->id,
+    'subject_id' => $revenue->id,
+    'value' => 50000,
+    'desc' => 'بستانکار',
+])->create();
+```
+
+### سایر فکتوری‌ها
+`SubjectFactory` و `CompanyFactory` برای ساخت دادهٔ پایه در تست‌ها کاربردی هستند. توجه کنید که `SubjectFactory` مقدار `company_id` را تعیین نمی‌کند؛ اگر می‌خواهید سرفصل به شرکت خاصی تعلق داشته باشد، مقدار را خودتان تعیین کنید یا قبل از ساخت، session شرکت فعال را ست کنید.【F:database/factories/SubjectFactory.php†L17-L22】
+
+## نکات تکمیلی
+- هنگام تست متد `deleteDocument` یا `updateDocument` بهتر است از `Document::factory()` استفاده کنید تا شماره سند معتبر تولید شود.
+- از آنجا که متدهای سرویس برای ولیدیشن به `Validator` تکیه دارند، تست‌هایی که انتظار خطا دارند باید پیام عمومی استثناء را بررسی کنند (برای `createDocument` از `DocumentServiceException` و برای سایر متدها از `\Exception`).
+
+## برنامه‌های آینده
+- **Helper موازنه سند:** تابعی برای محاسبه یا گزارش مانده‌ی سند هنوز نوشته نشده است و در تست‌ها باید مجموع `value` را دستی بسنجید.
+- **مقایسهٔ خودکار جمع بدهکار/بستانکار در فکتوری‌ها:** در حال حاضر فکتوری‌ها جمع مانده را کنترل نمی‌کنند؛ در آینده می‌توان stateهای کمکی برای تولید اسناد متوازن اضافه کرد.
+
+## اجرای تست‌ها
 
 ```bash
-# Run all test
-php artisan test
-
-# اجرای تست‌های خاص
+php artisan test                # اجرای تمام تست‌ها
 php artisan test --testsuite=Unit
 php artisan test --testsuite=Feature
-
-# اجرای تست‌های یک کلاس خاص
-php artisan test tests/Feature/DocumentTest.php
-
-# اجرای یک تست خاص
-php artisan test --filter test_user_can_create_document
-
-# اجرای با گزارش Coverage
-php artisan test --coverage
-
-# اجرای با جزئیات بیشتر
-php artisan test --verbose
+php artisan test --filter=DocumentServiceTest
 ```
 
-### تنظیمات محیط تست
+در صورت نیاز به دیتابیس SQLite در حافظه، مقادیر زیر را در فایل env تست قرار دهید:
 
-```php
+```ini
 APP_ENV=testing
 DB_CONNECTION=sqlite
 DB_DATABASE=:memory:
@@ -738,117 +325,4 @@ SESSION_DRIVER=array
 QUEUE_CONNECTION=sync
 ```
 
-## 🔧 ابزارهای کمکی تست
-
-### Custom Assertions
-
-```php
-<?php
-namespace Tests;
-
-use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
-
-abstract class TestCase extends BaseTestCase
-{
-    use CreatesApplication;
-    
-    protected function assertDocumentIsBalanced($document)
-    {
-        $this->assertEquals(
-            $document->total_debit,
-            $document->total_credit,
-            'سند متوازن نیست'
-        );
-    }
-    
-    protected function assertAccountBalance($accountId, $expectedBalance)
-    {
-        $actualBalance = Transaction::where('subject_id', $accountId)
-            ->sum(DB::raw('debit_amount - credit_amount'));
-            
-        $this->assertEquals(
-            $expectedBalance,
-            $actualBalance,
-            "مانده حساب با مقدار مورد انتظار برابر نیست"
-        );
-    }
-}
-```
-
-### Test Traits
-
-```php
-<?php
-namespace Tests\Traits;
-
-use App\Models\User;
-use App\Models\Company;
-use App\Models\FiscalYear;
-
-trait SetsUpTestData
-{
-    protected function setUpTestCompany(): Company
-    {
-        $company = Company::factory()->create();
-        $fiscalYear = FiscalYear::factory()->create([
-            'company_id' => $company->id
-        ]);
-        
-        session(['active-company-id' => $company->id]);
-        
-        return $company;
-    }
-    
-    protected function actingAsUser($permissions = []): User
-    {
-        $user = User::factory()->create();
-        
-        if (!empty($permissions)) {
-            $user->givePermissionTo($permissions);
-        }
-        
-        $this->actingAs($user);
-        
-        return $user;
-    }
-}
-```
-
-## 📊 تست گزارش‌ها
-
-```php
-public function test_ledger_report_accuracy()
-{
-    // Arrange
-    $account = Subject::factory()->create(['type' => 'asset']);
-    
-    // ایجاد تراکنش‌های مختلف
-    $this->createTransaction($account, 100000, 0); // +100000
-    $this->createTransaction($account, 50000, 0);  // +50000
-    $this->createTransaction($account, 0, 30000);  // -30000
-    
-    // Act
-    $ledgerData = app(ReportService::class)->generateLedger($account->id);
-    
-    // Assert
-    $this->assertEquals(120000, $ledgerData['final_balance']);
-    $this->assertCount(3, $ledgerData['transactions']);
-}
-
-private function createTransaction($account, $debit, $credit)
-{
-    $document = Document::factory()->create();
-    
-    Transaction::create([
-        'document_id' => $document->id,
-        'subject_id' => $account->id,
-        'debit_amount' => $debit,
-        'credit_amount' => $credit,
-        'description' => 'تراکنش تست'
-    ]);
-}
-```
-
----
-
-**نکته مهم**: همیشه قبل از commit کردن تغییرات، تمام تست‌ها را اجرا کنید و مطمئن شوید که همه موفق هستند. در سیستم‌های مالی، هیچ تست شکست خورده‌ای نباید نادیده گرفته شود.
+همیشه پیش از ارسال Pull Request تمام تست‌ها را اجرا کنید و اگر تستی به دلیل کمبود قابلیت فعلی شکست خورد، موضوع را به‌عنوان کار آینده مستند کنید.


### PR DESCRIPTION
## Summary
- rewrite the testing guide to document the real DocumentService API, transaction value storage, and StoreTransactionRequest validation
- replace outdated examples with working unit and feature test samples that use the existing DocumentFactory and TransactionFactory
- note limitations such as missing balance helpers and highlight future work items instead of presenting them as implemented

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ce7fbe6354832a9acd0471361bbc05